### PR TITLE
Fix context attributes

### DIFF
--- a/nsaph_utils/utils/context.py
+++ b/nsaph_utils/utils/context.py
@@ -133,6 +133,7 @@ class Argument:
     def __str__(self):
         return "--" + self.name
 
+
 class Context:
     """
     Generic class allowing to build context and configuration objects
@@ -190,14 +191,14 @@ class Context:
             self.description = subclass.__doc__
 
         self._attrs = [
-            attr[1:] for attr in subclass.__dict__
-            if attr[0] == '_' and attr[1] != '_'
+            field_name[1:] for field_name, field in subclass.__dict__.items()
+            if isinstance(field, Argument)
         ]
 
         if include_default:
             self._attrs += [
-                attr[1:] for attr in Context.__dict__
-                if attr[0] == '_' and attr[1] != '_' and attr[1:] not in self._attrs
+                field_name[1:] for field_name, field in Context.__dict__.items()
+                if isinstance(field, Argument) and field_name[1:] not in self._attrs
             ]
 
     def instantiate(self):


### PR DESCRIPTION
Fixed way to get command line arguments, to avoid the exception
```
  File "/root/anaconda/envs/nsaph/lib/python3.8/site-packages/nsaph_utils/utils/context.py", line 209, in instantiate
    return self._instantiate()
  File "/root/anaconda/envs/nsaph/lib/python3.8/site-packages/nsaph_utils/utils/context.py", line 223, in _instantiate
    arg.add_to(parser)
AttributeError: 'function' object has no attribute 'add_to'
```
Exception was appear because of new `_instantiate` method.